### PR TITLE
feat(behavior-tree): calling `Reset()` now triggers End on active nodes

### DIFF
--- a/Assets/FluidBehaviorTree/Runtime/Decorators/DecoratorBase.cs
+++ b/Assets/FluidBehaviorTree/Runtime/Decorators/DecoratorBase.cs
@@ -13,7 +13,7 @@ namespace CleverCrow.Fluid.BTs.Decorators {
         public bool Enabled { get; set; } = true;
 
         public GameObject Owner { get; set; }
-        public BehaviorTree ParentTree { get; set; }
+        public IBehaviorTree ParentTree { get; set; }
         public TaskStatus LastStatus { get; private set; }
 
         public ITask Child => Children.Count > 0 ? Children[0] : null;

--- a/Assets/FluidBehaviorTree/Runtime/TaskParents/TaskParentBase.cs
+++ b/Assets/FluidBehaviorTree/Runtime/TaskParents/TaskParentBase.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace CleverCrow.Fluid.BTs.TaskParents {
     public abstract class TaskParentBase : ITaskParent {
-        public BehaviorTree ParentTree { get; set; }
+        public IBehaviorTree ParentTree { get; set; }
         public TaskStatus LastStatus { get; private set; }
 
         public string Name { get; set; }

--- a/Assets/FluidBehaviorTree/Runtime/Tasks/ITask.cs
+++ b/Assets/FluidBehaviorTree/Runtime/Tasks/ITask.cs
@@ -22,7 +22,7 @@ namespace CleverCrow.Fluid.BTs.Tasks {
         /// <summary>
         /// Tree this node belongs to
         /// </summary>
-        BehaviorTree ParentTree { get; set; }
+        IBehaviorTree ParentTree { get; set; }
 
         /// <summary>
         /// Last status returned by Update

--- a/Assets/FluidBehaviorTree/Runtime/Tasks/TaskBase.cs
+++ b/Assets/FluidBehaviorTree/Runtime/Tasks/TaskBase.cs
@@ -7,11 +7,12 @@ namespace CleverCrow.Fluid.BTs.Tasks {
         private bool _start;
         private bool _exit;
         private int _lastTickCount;
+        private bool _active;
 
         public string Name { get; set; }
         public bool Enabled { get; set; } = true;
         public GameObject Owner { get; set; }
-        public BehaviorTree ParentTree { get; set; }
+        public IBehaviorTree ParentTree { get; set; }
 
         public TaskStatus LastStatus { get; private set; }
 
@@ -32,9 +33,12 @@ namespace CleverCrow.Fluid.BTs.Tasks {
             var status = GetUpdate();
             LastStatus = status;
 
-            // Soft reset since the node has completed
             if (status != TaskStatus.Continue) {
+                if (_active) ParentTree?.RemoveActiveTask(this);
                 Exit();
+            } else if (!_active) {
+                ParentTree?.AddActiveTask(this);
+                _active = true;
             }
 
             return status;
@@ -56,6 +60,7 @@ namespace CleverCrow.Fluid.BTs.Tasks {
         /// Reset the node to be re-used
         /// </summary>
         public void Reset () {
+            _active = false;
             _start = false;
             _exit = false;
         }

--- a/Assets/FluidBehaviorTree/Tests/Editor/BehaviorTrees/BehaviorTreeTest.cs
+++ b/Assets/FluidBehaviorTree/Tests/Editor/BehaviorTrees/BehaviorTreeTest.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using CleverCrow.Fluid.BTs.TaskParents.Composites;
 using CleverCrow.Fluid.BTs.Tasks;
+using CleverCrow.Fluid.BTs.Testing;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -121,6 +123,27 @@ namespace CleverCrow.Fluid.BTs.Trees.Testing {
                 
                 Assert.AreEqual(1, _tree.TickCount);
             }
+            
+            [Test]
+            public void It_should_call_End_on_active_nodes () {
+                var task = A.TaskStub().Build();
+                
+                _tree.AddActiveTask(task);
+                _tree.Reset();
+                
+                task.Received(1).End();
+            }
+            
+            [Test]
+            public void It_should_not_call_End_on_active_nodes_twice_if_called_again () {
+                var task = A.TaskStub().Build();
+                
+                _tree.AddActiveTask(task);
+                _tree.Reset();
+                _tree.Reset();
+
+                task.Received(1).End();
+            }
         }
 
         public class TickMethod : BehaviorTreeTest {
@@ -216,6 +239,29 @@ namespace CleverCrow.Fluid.BTs.Trees.Testing {
                     
                     _actionAlt.Received(0).Reset();
                 }
+            }
+        }
+
+        public class AddActiveTaskMethod : BehaviorTreeTest {
+            [Test]
+            public void It_should_add_an_active_task () {
+                var task = A.TaskStub().Build();
+                
+                _tree.AddActiveTask(task);
+
+                Assert.IsTrue(_tree.ActiveTasks.Contains(task));
+            }
+        }
+        
+        public class RemoveActiveTaskMethod : BehaviorTreeTest {
+            [Test]
+            public void It_should_add_an_active_task () {
+                var task = A.TaskStub().Build();
+                
+                _tree.AddActiveTask(task);
+                _tree.RemoveActiveTask(task);
+
+                Assert.IsFalse(_tree.ActiveTasks.Contains(task));
             }
         }
     }


### PR DESCRIPTION
Previously calling reset on a BehaviorTree did not call `End()` because it was not performant. Nodes
that return continue on a tree are now registered as active and removed after returning continue.
Allowing them to be discovered at the top level by the BehaviorTree without traversing the entire
system.