### PR TITLE
fix(actions): generic action had exit and init reversed

### DIFF
--- a/Assets/FluidBehaviorTree/Runtime/Tasks/Actions/ActionGeneric.cs
+++ b/Assets/FluidBehaviorTree/Runtime/Tasks/Actions/ActionGeneric.cs
@@ -20,11 +20,11 @@ namespace CleverCrow.Fluid.BTs.Tasks.Actions {
         }
 
         protected override void OnExit () {
-            initLogic?.Invoke();
+            exitLogic?.Invoke();
         }
 
         protected override void OnInit () {
-            exitLogic?.Invoke();
+            initLogic?.Invoke();
         }
     }
 }

--- a/Assets/FluidBehaviorTree/Tests/Editor/Tasks/Actions/ActionGenericTest.cs
+++ b/Assets/FluidBehaviorTree/Tests/Editor/Tasks/Actions/ActionGenericTest.cs
@@ -45,6 +45,19 @@ namespace CleverCrow.Fluid.BTs.Testing {
             }
 
             [Test]
+            public void It_should_execute_init_hook_on_continue () {
+                var test = 0;
+                var task = new ActionGeneric {
+                    initLogic = () => { test++; },
+                    updateLogic = () => TaskStatus.Continue,
+                };
+
+                task.Update();
+
+                Assert.AreEqual(1, test);
+            }
+
+            [Test]
             public void It_should_execute_a_exit_hook () {
                 var test = 0;
                 var task = new ActionGeneric {


### PR DESCRIPTION
Didn't seem to cause any problems. But would have definitely caused issues with extending the ActionGeneric class.

#35