### PR TITLE
fix(conditions): generic condition had exit and init reversed

### DIFF
--- a/Assets/FluidBehaviorTree/Runtime/Tasks/Conditions/ConditionGeneric.cs
+++ b/Assets/FluidBehaviorTree/Runtime/Tasks/Conditions/ConditionGeneric.cs
@@ -20,11 +20,11 @@ namespace CleverCrow.Fluid.BTs.Tasks {
         }
 
         protected override void OnExit () {
-            initLogic?.Invoke();
+            exitLogic?.Invoke();
         }
 
         protected override void OnInit () {
-            exitLogic?.Invoke();
+            initLogic?.Invoke();
         }
     }
 }

--- a/Assets/FluidBehaviorTree/Tests/Editor/Tasks/Conditions/ConditionGenericTest.cs
+++ b/Assets/FluidBehaviorTree/Tests/Editor/Tasks/Conditions/ConditionGenericTest.cs
@@ -44,6 +44,20 @@ namespace CleverCrow.Fluid.BTs.Testing {
                 Assert.AreEqual(1, test);
             }
 
+            
+            [Test]
+            public void It_should_execute_init_hook_before_update () {
+                var test = 0;
+                var task = new ConditionGeneric {
+                    initLogic = () => { test++; },
+                    updateLogic = () => { return test == 1; }
+                };
+
+                task.Update();
+
+                Assert.AreEqual(task.LastStatus, TaskStatus.Success);
+            }
+
             [Test]
             public void It_should_execute_a_exit_hook () {
                 var test = 0;


### PR DESCRIPTION
Didn't seem to cause any problems. But would have definitely caused issues with extending the
ConditionGeneric class.