### PR TITLE
feat(visualizer): pausing the game now keeps active node highlighting

### DIFF
--- a/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/BehaviorTreeWindow.cs
+++ b/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/BehaviorTreeWindow.cs
@@ -22,7 +22,7 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
             if (!Application.isPlaying) {
                 ClearView();
             }
-            
+
             GUILayout.Label($"Behavior Tree: {_name}", EditorStyles.boldLabel);
             _printer?.Print(position.size);
         }
@@ -36,6 +36,20 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
             if (Application.isPlaying) {
                 Repaint();
             }
+        }
+
+        void OnEnable() {
+            EditorApplication.update += OnEditorUpdate;
+        }
+
+        void OnDisable() {
+            EditorApplication.update -= OnEditorUpdate;
+        }
+
+        private void OnEditorUpdate() {
+            // Update faders separately so the current state is maintained when the game is paused
+            if (!EditorApplication.isPaused)
+                _printer?.UpdateFaders();
         }
     }
 }

--- a/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/Printer/BehaviorTreePrinter.cs
+++ b/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/Printer/BehaviorTreePrinter.cs
@@ -8,7 +8,7 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
         private readonly Rect _containerSize;
 
         private Vector2 _scrollPosition;
-        
+
         public static StatusIcons StatusIcons { get; private set; }
         public static GuiStyleCollection SharedStyles { get; private set; }
 
@@ -16,14 +16,14 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
         public BehaviorTreePrinter (IBehaviorTree tree, Vector2 windowSize) {
             StatusIcons = new StatusIcons();
             SharedStyles = new GuiStyleCollection();
-            
+
             var container = new GraphContainerVertical();
             container.SetGlobalPosition(SCROLL_PADDING, SCROLL_PADDING);
             _root = new VisualTask(tree.Root, container);
             container.CenterAlignChildren();
-            
-            _containerSize = new Rect(0, 0, 
-                container.Width + SCROLL_PADDING * 2, 
+
+            _containerSize = new Rect(0, 0,
+                container.Width + SCROLL_PADDING * 2,
                 container.Height + SCROLL_PADDING * 2);
 
             CenterScrollView(windowSize, container);
@@ -37,8 +37,8 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
 
         public void Print (Vector2 windowSize) {
             _scrollPosition = GUI.BeginScrollView(
-                new Rect(0, 0, windowSize.x, windowSize.y), 
-                _scrollPosition, 
+                new Rect(0, 0, windowSize.x, windowSize.y),
+                _scrollPosition,
                 _containerSize);
             _root.Print();
             GUI.EndScrollView();
@@ -46,6 +46,10 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
 
         public void Unbind () {
             _root.RecursiveTaskUnbind();
+        }
+
+        public void UpdateFaders () {
+            _root.UpdateFaders();
         }
     }
 }

--- a/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/Printer/NodePrintController.cs
+++ b/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/Printer/NodePrintController.cs
@@ -28,7 +28,6 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
 
         public void Print (bool taskIsActive) {
             if (!(_node.Task is TaskRoot)) PaintVerticalTop();
-            _faders.Update(taskIsActive);
 
             PaintBody();
 
@@ -141,6 +140,10 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
             texture.Apply();
 
             return texture;
+        }
+
+        public void SyncFade (bool taskIsActive) {
+            _faders.Update(taskIsActive);
         }
     }
 }

--- a/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/Printer/VisualTask.cs
+++ b/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/Printer/VisualTask.cs
@@ -9,10 +9,10 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
 
         public ITask Task { get; }
         public IReadOnlyList<VisualTask> Children => _children;
-        
+
         public float Width { get; } = 70;
         public float Height { get; } = 50;
-        
+
         public IGraphBox Box { get; private set; }
         public IGraphBox Divider { get; private set; }
         public float DividerLeftOffset { get; private set; }
@@ -20,7 +20,7 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
         public VisualTask (ITask task, IGraphContainer parentContainer) {
             Task = task;
             BindTask();
-            
+
             var container = new GraphContainerVertical();
 
             AddBox(container);
@@ -30,13 +30,13 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
                 foreach (var child in task.Children) {
                     _children.Add(new VisualTask(child, childContainer));
                 }
-                
+
                 AddDivider(container, childContainer);
                 container.AddBox(childContainer);
             }
 
             parentContainer.AddBox(container);
-            
+
             _printer = new NodePrintController(this);
         }
 
@@ -46,7 +46,7 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
 
         public void RecursiveTaskUnbind () {
             Task.EditorUtils.EventActive.RemoveListener(UpdateTaskActiveStatus);
-            
+
             foreach (var child in _children) {
                 child.RecursiveTaskUnbind();
             }
@@ -79,10 +79,18 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
 
         public void Print () {
             _printer.Print(_taskActive);
-            _taskActive = false;
 
             foreach (var child in _children) {
                 child.Print();
+            }
+        }
+
+        public void UpdateFaders () {
+            _printer.SyncFade(_taskActive);
+            _taskActive = false;
+
+            foreach (var child in _children) {
+                child.UpdateFaders();
             }
         }
     }


### PR DESCRIPTION
The game used to clear all activate highlighting on pause. Making it hard to figure out what the BT was up to before pausing.

fix #94