### PR TITLE
Fix Composites and Sub-Trees not ending their Children when exited

### DIFF
--- a/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/Printer/VisualTask.cs
+++ b/Assets/com.fluid.behavior-tree/Editor/BehaviorTree/Printer/VisualTask.cs
@@ -25,7 +25,7 @@ namespace CleverCrow.Fluid.BTs.Trees.Editors {
 
             AddBox(container);
 
-            if (task.Children != null) {
+            if (task.Children != null && task.Children.Count > 0) {
                 var childContainer = new GraphContainerHorizontal();
                 foreach (var child in task.Children) {
                     _children.Add(new VisualTask(child, childContainer));

--- a/Assets/com.fluid.behavior-tree/Runtime/BehaviorTree/Builder/BehaviorTreeBuilder.cs
+++ b/Assets/com.fluid.behavior-tree/Runtime/BehaviorTree/Builder/BehaviorTreeBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using CleverCrow.Fluid.BTs.Decorators;
 using CleverCrow.Fluid.BTs.TaskParents;
@@ -179,7 +179,9 @@ namespace CleverCrow.Fluid.BTs.Trees {
         }
 
         public BehaviorTreeBuilder Splice (BehaviorTree tree) {
-            _tree.Splice(PointerCurrent, tree);
+            if (tree != null && tree.Root != null) {
+                _tree.Splice(PointerCurrent, tree);
+            }
 
             return this;
         }

--- a/Assets/com.fluid.behavior-tree/Runtime/TaskParents/Composites/CompositeBase.cs
+++ b/Assets/com.fluid.behavior-tree/Runtime/TaskParents/Composites/CompositeBase.cs
@@ -1,4 +1,4 @@
-﻿namespace CleverCrow.Fluid.BTs.TaskParents.Composites {
+namespace CleverCrow.Fluid.BTs.TaskParents.Composites {
     public abstract class CompositeBase : TaskParentBase {
         public int ChildIndex { get; protected set; }
 
@@ -12,6 +12,10 @@
             ChildIndex = 0;
 
             base.Reset();
+        }
+
+        protected void NotifyChildEnd(int childEnding) {
+            Children[childEnding].End();
         }
     }
 }

--- a/Assets/com.fluid.behavior-tree/Runtime/TaskParents/Composites/Selector.cs
+++ b/Assets/com.fluid.behavior-tree/Runtime/TaskParents/Composites/Selector.cs
@@ -1,4 +1,4 @@
-﻿using CleverCrow.Fluid.BTs.Tasks;
+using CleverCrow.Fluid.BTs.Tasks;
 
 namespace CleverCrow.Fluid.BTs.TaskParents.Composites {
     public class Selector : CompositeBase {
@@ -10,9 +10,13 @@ namespace CleverCrow.Fluid.BTs.TaskParents.Composites {
 
                 switch (child.Update()) {
                     case TaskStatus.Success:
+                        NotifyChildEnd(ChildIndex);
                         return TaskStatus.Success;
                     case TaskStatus.Continue:
                         return TaskStatus.Continue;
+                    case TaskStatus.Failure:
+                        NotifyChildEnd(ChildIndex);
+                        break;
                 }
 
                 ChildIndex++;

--- a/Assets/com.fluid.behavior-tree/Runtime/TaskParents/Composites/SelectorRandom.cs
+++ b/Assets/com.fluid.behavior-tree/Runtime/TaskParents/Composites/SelectorRandom.cs
@@ -21,9 +21,13 @@ namespace CleverCrow.Fluid.BTs.TaskParents.Composites {
 
                 switch (child.Update()) {
                     case TaskStatus.Success:
+                        NotifyChildEnd(ChildIndex);
                         return TaskStatus.Success;
                     case TaskStatus.Continue:
                         return TaskStatus.Continue;
+                    case TaskStatus.Failure:
+                        NotifyChildEnd(ChildIndex);
+                        break;
                 }
 
                 ChildIndex++;

--- a/Assets/com.fluid.behavior-tree/Runtime/TaskParents/Composites/Sequence.cs
+++ b/Assets/com.fluid.behavior-tree/Runtime/TaskParents/Composites/Sequence.cs
@@ -1,4 +1,4 @@
-﻿using CleverCrow.Fluid.BTs.Tasks;
+using CleverCrow.Fluid.BTs.Tasks;
 
 namespace CleverCrow.Fluid.BTs.TaskParents.Composites {
     public class Sequence : CompositeBase {
@@ -9,8 +9,17 @@ namespace CleverCrow.Fluid.BTs.TaskParents.Composites {
                 var child = Children[ChildIndex];
 
                 var status = child.Update();
-                if (status != TaskStatus.Success) {
-                    return status;
+                switch (status) {
+                    case TaskStatus.Success:
+                        NotifyChildEnd(ChildIndex);
+                        break;
+                    case TaskStatus.Failure:
+                        NotifyChildEnd(ChildIndex);
+                        return status;
+                    case TaskStatus.Continue:
+                        return status;
+                    default:
+                        break;
                 }
 
                 ChildIndex++;

--- a/Assets/com.fluid.behavior-tree/Runtime/TaskParents/TaskRoot.cs
+++ b/Assets/com.fluid.behavior-tree/Runtime/TaskParents/TaskRoot.cs
@@ -1,4 +1,4 @@
-﻿using CleverCrow.Fluid.BTs.Tasks;
+using CleverCrow.Fluid.BTs.Tasks;
 
 namespace CleverCrow.Fluid.BTs.TaskParents {
     public class TaskRoot : TaskParentBase {
@@ -16,6 +16,8 @@ namespace CleverCrow.Fluid.BTs.TaskParents {
         }
 
         public override void End () {
+            var child = Children[0];
+            child.End();
         }
     }
 }


### PR DESCRIPTION
(Plus a couple of null deref fixes.)

I was having issues when I first set up this plugin on my work project; various stateful things were hanging around unexpectedly. I realised this was missing, and once added, everything has worked well with it for the past 8 months (the game is in Early Access: https://store.steampowered.com/app/1724030/Eyes_of_Hellfire/).

I couldn't get those random changed 'using' directives to not show as modified, whatever I tried to do with line endings in VS and git, so hopefully not an issue!

And thanks for the super helpful plugin! It was just the thing I needed to stand up a bunch of AI behaviours with minimal code.